### PR TITLE
Roster: Fix unicode á characters

### DIFF
--- a/elected-officials-roster/state_house_elected_officials.csv
+++ b/elected-officials-roster/state_house_elected_officials.csv
@@ -3554,7 +3554,7 @@ NMlower66,35066,NM,lower,66,R,Bob,Wooley,0,0,0,0,11/6/18
 NMlower67,35067,NM,lower,67,R,Dennis,Roch,0,0,0,0,11/6/18
 NMlower68,35068,NM,lower,68,R,Monica,Youngblood,0,0,0,0,11/6/18
 NMlower69,35069,NM,lower,69,D,Harry,Garcia,0,0,0,0,11/6/18
-NMlower70,35070,NM,lower,70,D,Tom√°s,Salazar,0,0,0,0,11/6/18
+NMlower70,35070,NM,lower,70,D,Tomás,Salazar,0,0,0,0,11/6/18
 NVlower1,32001,NV,lower,1,D,Daniele,Monroe-Moreno,0,0,0,0,11/6/18
 NVlower2,32002,NV,lower,2,R,John,Hambrick,0,0,0,0,11/6/18
 NVlower3,32003,NV,lower,3,D,Nelson,Araujo,0,0,0,0,11/6/18

--- a/elected-officials-roster/us_congress_elected_officials.csv
+++ b/elected-officials-roster/us_congress_elected_officials.csv
@@ -48,7 +48,7 @@ CA25,6025,CA,25,R,Steve,Knight,0,0,0,0,0,11/6/18
 CA26,6026,CA,26,D,Julia,Brownley,0,0,0,0,0,11/6/18
 CA27,6027,CA,27,D,Judy,Chu,0,0,0,0,0,11/6/18
 CA28,6028,CA,28,D,Adam,Schiff,0,0,0,0,0,11/6/18
-CA29,6029,CA,29,D,Tony,C√°rdenas,0,0,0,0,0,11/6/18
+CA29,6029,CA,29,D,Tony,Cárdenas,0,0,0,0,0,11/6/18
 CA30,6030,CA,30,D,Brad,Sherman,0,0,0,0,0,11/6/18
 CA31,6031,CA,31,D,Pete,Aguilar,0,0,0,0,0,11/6/18
 CA32,6032,CA,32,D,Grace,Napolitano,0,0,0,0,0,11/6/18
@@ -57,13 +57,13 @@ CA34,6034,CA,34,D,Jimmy,Gomez,0,0,0,0,0,11/6/18
 CA35,6035,CA,35,D,Norma,Torres,0,0,0,0,0,11/6/18
 CA36,6036,CA,36,D,Raul,Ruiz,0,0,0,0,0,11/6/18
 CA37,6037,CA,37,D,Karen,Bass,0,0,0,0,0,11/6/18
-CA38,6038,CA,38,D,Linda,S√°nchez,0,0,0,0,0,11/6/18
+CA38,6038,CA,38,D,Linda,Sánchez,0,0,0,0,0,11/6/18
 CA39,6039,CA,39,R,Ed,Royce,0,0,0,0,0,11/6/18
 CA40,6040,CA,40,D,Lucille,Roybal-Allard,0,0,0,0,0,11/6/18
 CA41,6041,CA,41,D,Mark,Takano,0,0,0,0,0,11/6/18
 CA42,6042,CA,42,R,Ken,Calvert,0,0,0,0,0,11/6/18
 CA43,6043,CA,43,D,Maxine,Waters,0,0,0,0,0,11/6/18
-CA44,6044,CA,44,D,Nanette,Barrag√°n,0,0,0,0,0,11/6/18
+CA44,6044,CA,44,D,Nanette,Barragán,0,0,0,0,0,11/6/18
 CA45,6045,CA,45,R,Mimi,Walters,0,0,0,0,0,11/6/18
 CA46,6046,CA,46,D,J. Luis,Correa,0,0,0,0,0,11/6/18
 CA47,6047,CA,47,D,Alan,Lowenthal,0,0,0,0,0,11/6/18
@@ -262,7 +262,7 @@ NY3,36003,NY,3,D,Thomas,Suozzi,0,0,0,0,0,11/6/18
 NY4,36004,NY,4,D,Kathleen,Rice,0,0,0,0,0,11/6/18
 NY5,36005,NY,5,D,Gregory W.,Meeks,0,0,0,0,0,11/6/18
 NY6,36006,NY,6,D,Grace,Meng,0,0,0,0,0,11/6/18
-NY7,36007,NY,7,D,Nydia M.,Vel√°zquez,0,0,0,0,0,11/6/18
+NY7,36007,NY,7,D,Nydia M.,Velázquez ,0,0,0,0,0,11/6/18
 NY8,36008,NY,8,D,Hakeem,Jeffries,0,0,0,0,0,11/6/18
 NY9,36009,NY,9,D,Yvette D.,Clarke,0,0,0,0,0,11/6/18
 NY10,36010,NY,10,D,Jerrold,Nadler,0,0,0,0,0,11/6/18


### PR DESCRIPTION
There are a handful of names that include `á` but were written as `√°`